### PR TITLE
HP-LensLocalID

### DIFF
--- a/hp_tool/HPSpreadsheet.py
+++ b/hp_tool/HPSpreadsheet.py
@@ -192,7 +192,7 @@ class HPSpreadsheet(Toplevel):
             validValues = {'instructions':'Date/Time, specified as \"YYYY:MM:DD HH:mm:SS\"'}
         elif currentCol == 'FileType':
             validValues = {'instructions':'Any file extension, without the dot (.) (e.g. jpg, png)'}
-        elif currentCol == 'HP-LensLocalId':
+        elif currentCol == 'HP-LensLocalID':
             validValues = {'instructions':'Local ID number (PAR, RIT) of lens'}
         else:
             validValues = {'instructions':'Any string of text'}

--- a/hp_tool/hp_data.py
+++ b/hp_tool/hp_data.py
@@ -308,7 +308,7 @@ def build_rit_file(imageList, info, csvFile, newNameList=None):
         ritWriter = csv.writer(csv_rit, lineterminator='\n', quoting=csv.QUOTE_ALL)
         if newFile:
             ritWriter.writerow(['ImageFilename', 'HP-CollectionRequestID', 'HP-HDLocation', 'OriginalImageName', 'MD5',
-                                    'CameraModel', 'DeviceSN', 'HP-DeviceLocalID', 'LensModel','LensSN', 'HP-LensLocalId', 'FileType', 'HP-JpgQuality',
+                                    'CameraModel', 'DeviceSN', 'HP-DeviceLocalID', 'LensModel','LensSN', 'HP-LensLocalID', 'FileType', 'HP-JpgQuality',
                                     'ShutterSpeed', 'Aperture', 'ExpCompensation', 'ISO', 'NoiseReduction', 'WhiteBalance',
                                     'HP-DegreesKelvin', 'ExposureMode', 'FlashFired', 'FocusMode', 'CreationDate', 'HP-Location',
                                     'GPSLatitude', 'GPSLongitude', 'CustomRendered', 'HP-OnboardFilter', 'HP-OBFilterType', 'BitDepth', 'ImageWidth', 'ImageHeight',

--- a/hp_tool/readme.txt
+++ b/hp_tool/readme.txt
@@ -53,7 +53,7 @@ OUTPUTS
 RIT CSV:
 The RIT CSV includes the following information for each image:
 "ImageFilename", "HP-CollectionRequestID", "HP-HDLocation", "OriginalImageName", "MD5","CameraModel", "DeviceSN","HP-DeviceLocalID" ,"LensModel",
-"LensSN", "HP-LensLocalId" ,"FileType" ,"HP-JpgQuality" ,"ShutterSpeed" ,"Aperture" ,"ExpCompensation" ,"ISO", "NoiseReduction", "WhiteBalance",
+"LensSN", "HP-LensLocalID" ,"FileType" ,"HP-JpgQuality" ,"ShutterSpeed" ,"Aperture" ,"ExpCompensation" ,"ISO", "NoiseReduction", "WhiteBalance",
 "HP-DegreesKelvin", "ExposureMode", "FlashFired", "FocusMode", "CreationDate", "HP-Location", "GPSLatitude", "GPSLongitude", "CustomRendered",
 "HP-OnboardFilter", "HP-OBFilterType", "BitDepth", "ImageWidth", "ImageHeight", "HP-LensFilter", "Type", "HP-Reflections", "HP-Shadows",
 "HP-HDR", "HP-CameraKinematics", "HP-App", "HP-Inside", "HP-Outside"


### PR DESCRIPTION
The lens local ID is referenced as "HP-LensLocalId" in some places and "HP-LensLocalID" in others.  This resolves the conflict, renaming everything to "HP-LensLocalID" following the capitalized "ID" convention from other fields.