### PR TITLE
Key paths through edge and node dictionary mappings that reference fi…

### DIFF
--- a/maskgen/MaskGenUI.py
+++ b/maskgen/MaskGenUI.py
@@ -942,6 +942,7 @@ class MakeGenUI(Frame):
             preferredFT = self.prefLoader.get_key('filetypes')
             if preferredFT:
                 self.scModel.setProjectData('typespref', preferredFT,excludeUpdate=True)
+                self.scModel.setProjectData('typespref', preferredFT,excludeUpdate=True)
             else:
                 self.scModel.setProjectData('typespref', getFileTypes(),excludeUpdate=True)
         self.createWidgets()

--- a/maskgen/MaskGenUI.py
+++ b/maskgen/MaskGenUI.py
@@ -942,7 +942,6 @@ class MakeGenUI(Frame):
             preferredFT = self.prefLoader.get_key('filetypes')
             if preferredFT:
                 self.scModel.setProjectData('typespref', preferredFT,excludeUpdate=True)
-                self.scModel.setProjectData('typespref', preferredFT,excludeUpdate=True)
             else:
                 self.scModel.setProjectData('typespref', getFileTypes(),excludeUpdate=True)
         self.createWidgets()

--- a/maskgen/description_dialog.py
+++ b/maskgen/description_dialog.py
@@ -943,7 +943,7 @@ class FilterCaptureDialog(tkSimpleDialog.Dialog):
         if self.argBox is not None:
             self.argBox.destroy()
         if arginfo is None:
-            arginfo = []
+            arginfo = {}
         operation = getOperationWithGroups(operationName)
         argumentTuples = [self.__buildTuple(arg, arginfo[arg], operation) for arg in arginfo]
         for k, v in operation.mandatoryparameters.iteritems():

--- a/maskgen/graph_auto_updates.py
+++ b/maskgen/graph_auto_updates.py
@@ -45,6 +45,9 @@ def updateJournal(scModel):
         _fixEdgeFiles(scModel)
         _fixBlend(scModel)
         upgrades.append('0.4.0308.adee798679')
+    if "0.4.0308.db2133eadc" not in upgrades:
+        _fixFileArgs(scModel)
+        upgrades.append('0.4.0308.db2133eadc')
     scModel.getGraph().setDataItem('jt_upgrades',upgrades,excludeUpdate=True)
     if scModel.getGraph().getDataItem('autopastecloneinputmask') is None:
         scModel.getGraph().setDataItem('autopastecloneinputmask','no')
@@ -58,6 +61,20 @@ def _fixValidationTime(scModel):
 def _fixLabels(scModel):
     for node in scModel.getNodeNames():
         scModel.labelNodes(node)
+
+def _fixFileArgs(scModel):
+    #  add all the known file paths for now
+    # rather than trying to find out which ones were actually used.
+    scModel.G.addEdgeFilePath('arguments.XMP File Name','')
+    scModel.G.addEdgeFilePath('arguments.qtfile', '')
+    scModel.G.addEdgeFilePath('arguments.pastemask', '')
+    scModel.G.addEdgeFilePath('arguments.PNG File Name', '')
+    scModel.G.addEdgeFilePath('arguments.convolutionkernel', '')
+    scModel.G.addEdgeFilePath('inputmaskname', 'inputmaskownership')
+    scModel.G.addEdgeFilePath('selectmasks.mask', '')
+    scModel.G.addEdgeFilePath('videomasks.videosegment', '')
+    scModel.G.addNodeFilePath('compositemaskname', '')
+    scModel.G.addNodeFilePath('donors.*', '')
 
 def _fixEdgeFiles(scModel):
     import shutil

--- a/maskgen/image_graph.py
+++ b/maskgen/image_graph.py
@@ -580,7 +580,7 @@ class ImageGraph:
         """
         if edgeFunc is not None:
             edgeFunc(edge)
-        for path, ownership in self.edgeFilePaths.iteritems():
+        for path, ownership in self.G.graph['edgeFilePaths'].iteritems():
             for pathvalue in getPathValues(edge, path):
                 if pathvalue and len(pathvalue) > 0 and (ownership not in edge or edge[ownership] == 'yes'):
                     f = os.path.abspath(os.path.join(self.dir, pathvalue))

--- a/maskgen/scenario_model.py
+++ b/maskgen/scenario_model.py
@@ -1667,7 +1667,7 @@ class ImageProjectModel:
         :param arguments:
         :return:
         """
-        if len(arguments) > 0:
+        if len(arguments) > 0 and opName != 'node':
             op = getOperationWithGroups(opName, fake=True)
             for k,v in op.mandatoryparameters.iteritems():
                 if k =='inputmaskname':

--- a/maskgen/scenario_model.py
+++ b/maskgen/scenario_model.py
@@ -2238,7 +2238,7 @@ class ImageProjectModel:
                 suffix = os.path.splitext(resolved[preferred])[1].lower()
             else:
                 suffix = preferred
-        target = os.path.join(tempfile.gettempdir(), self.G.new_name(os.path.split(filename)[1], suffix=suffix))
+        target = os.path.join(tempfile.gettempdir(), self.G.new_name(self.start, suffix=suffix))
         shutil.copy2(filename, target)
         msg = None
         try:

--- a/maskgen/software_loader.py
+++ b/maskgen/software_loader.py
@@ -75,8 +75,8 @@ class Operation:
     category = None
     includeInMask = False
     description = None
-    optionalparameters = []
-    mandatoryparameters = []
+    optionalparameters = {}
+    mandatoryparameters = {}
     rules = []
     analysisOperations = []
     transitions = []
@@ -86,16 +86,16 @@ class Operation:
     groupedCategories = None
     maskTransformFunction = None
 
-    def __init__(self, name='', category='', includeInMask=False, rules=list(), optionalparameters=list(),
-                 mandatoryparameters=list(), description=None, analysisOperations=list(), transitions=list(),
+    def __init__(self, name='', category='', includeInMask=False, rules=list(), optionalparameters=dict(),
+                 mandatoryparameters=dict(), description=None, analysisOperations=list(), transitions=list(),
                  compareparameters=dict(),generateMask = True,groupedOperations=None, groupedCategories = None,
                  maskTransformFunction=maskTransformFunction):
         self.name = name
         self.category = category
         self.includeInMask = includeInMask
         self.rules = rules
-        self.mandatoryparameters = mandatoryparameters if mandatoryparameters is not None else []
-        self.optionalparameters = optionalparameters if optionalparameters is not None else []
+        self.mandatoryparameters = mandatoryparameters if mandatoryparameters is not None else {}
+        self.optionalparameters = optionalparameters if optionalparameters is not None else {}
         self.description = description
         self.analysisOperations = analysisOperations
         self.transitions = transitions


### PR DESCRIPTION
…le names are externally managed from the image graph and tied into the operations definition so that operations with file type parameters can automatically be included in a prpoject's archived and managed as a file (e.g. removed when no longer referenced).