### PR TITLE
Added Prerequisite Warning

### DIFF
--- a/scripts/windows_installer.nsh
+++ b/scripts/windows_installer.nsh
@@ -16,6 +16,8 @@ Var USERDIR
 Var BRANCH 
 
 Section -Prerequisites
+
+    MessageBox MB_OK "Specific versions of each prerequisite are required for$\neverything to work properly.  Please verify that any previously$\ninstalled prerequisites match the following versions:$\n$\n$\tAnaconda2$\t$\t4.4.0$\n$\tFFmpeg$\t$\t$\t3.2.X$\n$\tExiftool$\t$\t$\t10.61$\n$\tOpenCV$\t$\t$\t2.4.13.X$\n$\tGraphViz$\t$\t$\t2.38"
 	
 	MessageBox MB_YESNO "Do you need the prerequisites installed?$\n(e.g. anaconda, exiftool, graphviz etc.)" /SD IDYES IDNO prereqs_installed
 	


### PR DESCRIPTION
Added message box to windows installer script to warn the user of what versions they will need of each prerequisite, in hopes of avoiding problems with users having the wrong versions installed prior to running the installer.