### PR TITLE
Updated Camera Retrieval Method and PRNU Fix

### DIFF
--- a/hp_tool/hp/CameraForm.py
+++ b/hp_tool/hp/CameraForm.py
@@ -266,7 +266,7 @@ class HP_Device_Form(Toplevel):
         :return: (string) Error message (if error), otherwise None
         """
         print 'Verifying local ID is not already in use...'
-        c = API_Camera_Handler(self, token=self.browser_token.get(), url='https://medifor.rankone.io')
+        c = API_Camera_Handler(self, token=self.browser_token.get(), url='https://medifor.rankone.io', given_id=self.questions["Local ID*"].get())
         local_id_reference = c.get_local_ids()
         if not local_id_reference:
             return 'Could not successfully connect to Medifor browser. Please check credentials.'

--- a/hp_tool/hp/HPSpreadsheet.py
+++ b/hp_tool/hp/HPSpreadsheet.py
@@ -777,7 +777,6 @@ class HPSpreadsheet(Toplevel):
         :return: dictionary containing an entry for each row, with what columns to highlight, and an error messages.
         """
         errors = {}
-        self.master.reload_ids()
         for row in range(0, self.pt.rows):
             db_configs = []
             image = self.pt.model.df['OriginalImageName'][row]

--- a/hp_tool/hp/camera_handler.py
+++ b/hp_tool/hp/camera_handler.py
@@ -4,16 +4,19 @@ import os
 import data_files
 import tkMessageBox
 
+
 class API_Camera_Handler:
     """
     Manages camera metadata. If cannot connect to browser, will load from data/devices.json
     :param url: base URL
     :param token: browser login token
+    :param given_id: camera local id to look up
     """
-    def __init__(self, master, url, token):
+    def __init__(self, master, url, token, given_id):
         self.master = master
         self.url = url
         self.token = token
+        self.given_id = given_id
         self.localIDs = []
         self.models_hp = []
         self.models_exif = []
@@ -21,7 +24,10 @@ class API_Camera_Handler:
         self.sn_exif = []
         self.all = {}
         self.source = None
-        self.load_data()
+        if given_id == "download_locally":
+            self.write_devices()
+        elif given_id != "":
+            self.load_data()
 
     def get_local_ids(self):
         return self.localIDs
@@ -47,11 +53,12 @@ class API_Camera_Handler:
     def load_data(self):
         try:
             headers = {'Authorization': 'Token ' + self.token, 'Content-Type': 'application/json'}
-            url = self.url + '/api/cameras/?fields=hp_device_local_id, hp_camera_model, exif_device_serial_number, exif_camera_model, exif_camera_make/'
+            url = self.url + '/api/cameras/filters/?fields=hp_device_local_id, hp_camera_model, exif_device_serial_number, exif_camera_model, exif_camera_make/'
+            camera_data = {"hp_device_local_id": {"type": "exact", "value": self.given_id}}
             print 'Updating camera list from browser API... ',
 
             while True:
-                response = requests.get(url, headers=headers)
+                response = requests.post(url, json=camera_data, headers=headers)
                 if response.status_code == requests.codes.ok:
                     r = json.loads(response.content)
                     for item in r['results']:
@@ -62,14 +69,20 @@ class API_Camera_Handler:
                             self.models_exif.append(configuration['exif_camera_model'])
                             self.makes_exif.append(configuration['exif_camera_make'])
                             self.sn_exif.append(configuration['exif_device_serial_number'])
-
-                    url = r['next']
-                    if url is None:
-                        break
+                    break
                 else:
                     raise requests.HTTPError()
             print 'complete.'
-            self.write_devices()
+
+            with open(data_files._LOCALDEVICES, 'a+') as j:
+                found = False
+                for item in json.load(j):
+                    if item == self.all.items()[0][0]:
+                        found = True
+                        break
+                if not found:
+                    json.dump(self.all, j, indent=4)
+
             self.source = 'remote'
         except:
             print 'Could not connect. Loading from local file... ',
@@ -94,5 +107,28 @@ class API_Camera_Handler:
             self.source = 'local'
 
     def write_devices(self):
+        try:
+            headers = {'Authorization': 'Token ' + self.token, 'Content-Type': 'application/json'}
+            url = self.url + '/api/cameras/filters/?fields=hp_device_local_id, hp_camera_model, exif_device_serial_number, exif_camera_model, exif_camera_make/'
+            camera_data = {"high_provenance": {"type": "exact", "value": True}}
+
+            print 'Downloading camera list from browser API... ',
+
+            while True:
+                response = requests.post(url, json=camera_data, headers=headers)
+                if response.status_code == requests.codes.ok:
+                    r = json.loads(response.content)
+                    for item in r['results']:
+                        self.all[item['hp_device_local_id']] = item
+
+                    url = r['next']
+                    if url is None:
+                        break
+                else:
+                    raise requests.HTTPError()
+            print 'complete.'
+        except:
+            print 'Could not connect to browser.  Try again later.'
+
         with open(data_files._LOCALDEVICES, 'w') as j:
             json.dump(self.all, j, indent=4)


### PR DESCRIPTION
Added a local id parameter to the camera list pulling function.  This allows the retrieval of the one camera's data, speeding up the retrieval time considerably.  Also added a button to download all HP cameras locally, replacing the single download of every camera's data from the database.  Finally, made the necessary changes for the calls to this function to work properly.

Also removed the date and time suffix on PRNU.