### PR TITLE
Fix for Windows Hanging problem

### DIFF
--- a/maskgen/video_tools.py
+++ b/maskgen/video_tools.py
@@ -444,13 +444,19 @@ def getMeta(file, with_frames=False, show_streams=False):
             ffmpegcommand.append(args)
         stdout_fd, stdout_path = tempfile.mkstemp('.txt', 'stdOut')
         stder_fd, stder_path = tempfile.mkstemp('.txt', 'stdEr')
-        p = Popen(ffmpegcommand, stdout=stdout_fd, stderr=stder_fd)
-        p.wait()
-        os.close(stdout_fd)
-        os.close(stder_fd)
         try:
-            return func(os.fdopen(os.open(stdout_path, os.O_RDONLY), 'r'), os.fdopen(os.open(stder_path, os.O_RDONLY), 'r'))
+            p = Popen(ffmpegcommand, stdout=stdout_fd, stderr=stder_fd)
+            p.wait()
         finally:
+            os.close(stdout_fd)
+            os.close(stder_fd)
+        try:
+            stdout_fd = os.fdopen(os.open(stdout_path, os.O_RDONLY), 'r')
+            stder_fd = os.fdopen(os.open(stder_path, os.O_RDONLY), 'r')
+            return func(stdout_fd,stder_fd)
+        finally:
+            stdout_fd.close()
+            stder_fd.close()
             os.remove(stdout_path)
             os.remove(stder_path)
 

--- a/tests/test_video_tools.py
+++ b/tests/test_video_tools.py
@@ -192,6 +192,8 @@ class TestVideoTools(TestSupport):
         return writer_main.filename, files
 
     def test_meta(self):
+        meta,frames = video_tools.getMeta(self.locateFile('tests/videos/sample1.mov'), with_frames=True)
+        self.assertEqual(803, len(frames['0']))
         meta,frames = video_tools.getMeta(self.locateFile('tests/videos/sample1.mov'),show_streams=True)
         self.assertEqual('yuv420p',meta[0]['pix_fmt'])
 


### PR DESCRIPTION
Resolves a hang on the windows platform associated with PIPE and Popen.

getMeta now has 2 methods to handle this problem- runProbe and RunProbewithFrames.

Also, test_meta unit test has be adjusted to test both methods.