### PR TITLE
Handle End_Time_Tuple is None

### DIFF
--- a/maskgen/video_tools.py
+++ b/maskgen/video_tools.py
@@ -497,7 +497,7 @@ def getShape(video_file):
     return width,height
 
 def getFrameCountOnly(video_file):
-    meta, frames = getMeta(video_file, show_streams=True, with_frames=True, media_types='video')
+    meta, frames = getMeta(video_file, show_streams=True, with_frames=True, media_types=['video'])
     index = ffmpeg_api.getStreamindexesOfType(meta,'video')[0]
     return len(frames[index])
 
@@ -507,7 +507,7 @@ def getFrameCount(video_file,start_time_tuple=(0,1),end_time_tuple=None):
     startcomplete = False
     framessince_start = 1 if start_time_tuple[0] == 0 else 0
     mask = {'starttime':0,'startframe':1,'endtime':0,'endframe':1,'frames':0,'rate':0}
-    meta, frames = getMeta(video_file, show_streams=True, with_frames=True, media_types='video')
+    meta, frames = getMeta(video_file, show_streams=True, with_frames=True, media_types=['video'])
     index = ffmpeg_api.getStreamindexesOfType(meta,'video')[0]
     rate = ffmpeg_api.getVideoFrameRate(meta,frames)
     video_frames = frames[index]
@@ -611,10 +611,13 @@ def getMaskSetForEntireVideoForTuples(video_file, start_time_tuple=(0,1), end_ti
                     try:
                        mask.update(maskSetFromConstraints(rate,start_time_tuple,(0, int(item['nb_frames']))))
                     except:
-                        mask.update(getFrameCount(video_file,start_time_tuple=start_time_tuple))
-                else:
+                        mask.update(getFrameCount(video_file,start_time_tuple=start_time_tuple)) #is this redundant/equal to below?
+                elif end_time_tuple is None:
                     # input provides frames, so assume constant frame rate as time is just a reference point
+                    mask.update(getFrameCount(video_file, start_time_tuple=start_time_tuple))
+                else:
                     mask.update(maskSetFromConstraints(rate, start_time_tuple, end_time_tuple))
+
                 mask['mask'] = np.zeros((int(item['height']),int(item['width'])),dtype = np.uint8)
             else:
                 mask['starttime'] = start_time_tuple[0] + (start_time_tuple[1]-1)/rate*1000.0

--- a/maskgen/video_tools.py
+++ b/maskgen/video_tools.py
@@ -611,7 +611,7 @@ def getMaskSetForEntireVideoForTuples(video_file, start_time_tuple=(0,1), end_ti
                     try:
                        mask.update(maskSetFromConstraints(rate,start_time_tuple,(0, int(item['nb_frames']))))
                     except:
-                        mask.update(getFrameCount(video_file,start_time_tuple=start_time_tuple)) #is this redundant/equal to below?
+                        mask.update(getFrameCount(video_file,start_time_tuple=start_time_tuple))
                 elif end_time_tuple is None:
                     # input provides frames, so assume constant frame rate as time is just a reference point
                     mask.update(getFrameCount(video_file, start_time_tuple=start_time_tuple))

--- a/tests/test_video_tools.py
+++ b/tests/test_video_tools.py
@@ -250,6 +250,7 @@ class TestVideoTools(TestSupport):
         self.assertEqual(21, result['startframe'])
 
     def test_frame_binding_ffr(self):
+
         result = video_tools.getMaskSetForEntireVideo('sample1_ffr.mov',
                                                       start_time='00:00:02.01',
                                                       end_time='00:00:59.29')
@@ -285,6 +286,14 @@ class TestVideoTools(TestSupport):
         self.assertEqual(2800.0, round(result[0]['endtime']))
         self.assertEqual(29, result[0]['endframe'])
         self.assertEqual(29 - 23 + 1, result[0]['frames'])
+
+        result = video_tools.getMaskSetForEntireVideo('videos/Sample2_ffr.mxf', start_time=21, end_time=None) #ffr vid with 'N/A' nbframes.
+        self._add_mask_files_to_kill(result)
+        self.assertEqual(567.0, round(result[0]['starttime']))
+        self.assertEqual(21, result[0]['startframe'])
+        self.assertEqual(44975.0, round(result[0]['endtime']))
+        self.assertEqual(1350, result[0]['endframe'])
+        self.assertEqual(1350 - 21 + 1, result[0]['frames'])
 
     def test_frame_binding_vfr(self):
 


### PR DESCRIPTION
Properly handles end_time_tuple being None when a fixed frame rate video has no nb_frames.

Added supporting unit test and sample video.